### PR TITLE
Fix broken relative markdown link in guide

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -17,7 +17,7 @@ variety of Rust types, which you can check out in the implementor list of
 [`FromPyObject`].
 
 [`FromPyObject`] is also implemented for your own Rust types wrapped as Python
-objects (see [the chapter about classes](class.md)).  There, in order to both be
+objects (see [the chapter about classes](../class.md)).  There, in order to both be
 able to operate on mutable references *and* satisfy Rust's rules of non-aliasing
 mutable references, you have to extract the PyO3 reference wrappers [`PyRef`]
 and [`PyRefMut`].  They work like the reference wrappers of


### PR DESCRIPTION
While browsing the guide on https://pyo3.rs/v0.13.2/conversions/traits.html, I discovered that the link to the class documentation in that doc is broken. The path to `class.md` in `traits.md` is incorrect and clicking it yields a 404.

I propose this fix to the doc link.